### PR TITLE
Enforce line lengths of no more than 120 characters

### DIFF
--- a/niftany_rubocop_ruby.yml
+++ b/niftany_rubocop_ruby.yml
@@ -205,10 +205,12 @@ Style/LineEndConcatenation:
                  line end.
   Enabled: false
 
+# Override style guide to allow length of up to 120 characters.
 Metrics/LineLength:
-  Description: 'Limit lines to 80 characters.'
+  Description: 'Limit lines to 120 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
-  Enabled: false
+  Enabled: true
+  Max: 120
 
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 10 lines of code.'


### PR DESCRIPTION
Rubocop's default of 80 seems too short. 120 is plenty long enough and keeps lines from going off excessively _ad infinitum_.