### PR TITLE
Disable RSpec's BeforeAfterAll rule

### DIFF
--- a/niftany_rubocop_rspec.yml
+++ b/niftany_rubocop_rspec.yml
@@ -40,3 +40,6 @@ RSpec/InstanceVariable:
 
 RSpec/DescribeClass:
   Enabled: true
+
+RSpec/BeforeAfterAll:
+  Enabled: false


### PR DESCRIPTION
We don't seem to ever need this, and ignore it locally in our repos. So,
why not just disable it? It only gives a warning if you use before(:all)
and I think we're pretty savvy enough that we're using it correctly when
we do.

For reference:
https://github.com/psu-libraries/cho/blob/master/.rubocop_todo.yml#L15-L29
https://github.com/psu-stewardship/scholarsphere/blob/develop/.rubocop_todo.yml#L84-L98