### PR TITLE
Add colorize to dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'niftany'

--- a/niftany.gemspec
+++ b/niftany.gemspec
@@ -1,4 +1,6 @@
 
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
   spec.name          = 'niftany'
   spec.version       = '0.2.0'
@@ -12,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
+  spec.add_dependency 'colorize',      '~> 0.8.1'
   spec.add_dependency 'erb_lint',      '~> 0.0.22'
   spec.add_dependency 'rubocop',       '~> 0.51', '<= 0.52.1'
   spec.add_dependency 'rubocop-rspec', '~> 1.22', '<= 1.22.2'


### PR DESCRIPTION
Adds the colorize gem to the list of dependencies. This is required to run the niftany executable script.