### PR TITLE
Updating rubocop and rubocop-rspec

### DIFF
--- a/exe/niftany
+++ b/exe/niftany
@@ -31,11 +31,13 @@ end
 
 def rubocop_options(options)
   return [] unless options.auto_correct
+
   ['--auto-correct']
 end
 
 def erblint_options(options)
   return ['--lint-all'] unless options.auto_correct
+
   ['--lint-all', '--autocorrect']
 end
 

--- a/niftany.gemspec
+++ b/niftany.gemspec
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
@@ -16,8 +15,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'colorize',      '~> 0.8.1'
   spec.add_dependency 'erb_lint',      '~> 0.0.22'
-  spec.add_dependency 'rubocop',       '~> 0.51', '<= 0.52.1'
-  spec.add_dependency 'rubocop-rspec', '~> 1.22', '<= 1.22.2'
+  spec.add_dependency 'rubocop',       '~> 0.61'
+  spec.add_dependency 'rubocop-rspec', '~> 1.3'
   spec.add_dependency 'scss_lint',     '~> 0.55'
 
   spec.add_development_dependency 'bundler', '~> 1.16'

--- a/niftany_rubocop_rails.yml
+++ b/niftany_rubocop_rails.yml
@@ -1,14 +1,4 @@
 ---
-AllCops:
-  Include:
-    - '**/Rakefile'
-    - '**/config.ru'
-  Exclude:
-    - 'db/**/*'
-    - 'script/**/*'
-    - 'tmp/**/*'
-    - 'vendor/**/*'
-
 Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: false

--- a/niftany_rubocop_ruby.yml
+++ b/niftany_rubocop_ruby.yml
@@ -1,6 +1,5 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.3
   DisplayCopNames: true
 
 Naming/AccessorMethodName:
@@ -356,7 +355,7 @@ Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: no_comma
   Enabled: true
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Description: >-
                 Checks for trailing comma in array and hash literals. Supported styles are:
                   comma
@@ -472,7 +471,7 @@ Lint/CircularArgumentReference:
   Description: "Don't refer to the keyword argument in the default value."
   Enabled: false
 
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Description: >-
                  Checks for condition placed in a confusing position relative to
                  the keyword.
@@ -543,13 +542,6 @@ Lint/RequireParentheses:
 
 Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
-  Enabled: false
-
-Lint/UnneededDisable:
-  Description: >-
-                 Checks for rubocop:disable comments that can be removed.
-                 Note: this cop is not disabled when disabling all cops.
-                 It must be explicitly disabled.
   Enabled: false
 
 Lint/Void:


### PR DESCRIPTION
Updates to the latest rubocop and rubocop-rspec, with changes necessary to enable Niftany to be incorporated into an existing project. The major change will be that Rails projects won't include any `Exclude` or `Include` directories, and you'll need to redefine those in your local `rubocop.yml` files if needed.