### PR TITLE
Adding the rubocop-rails gem

### DIFF
--- a/niftany.gemspec
+++ b/niftany.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'erb_lint', '~> 0.0.22'
   spec.add_dependency 'rubocop', '~> 0.61'
   spec.add_dependency 'rubocop-performance', '~> 1.1'
+  spec.add_dependency 'rubocop-rails', '~> 2.3'
   spec.add_dependency 'rubocop-rspec', '~> 1.3'
   spec.add_dependency 'scss_lint', '~> 0.55'
 

--- a/niftany_rubocop_rails.yml
+++ b/niftany_rubocop_rails.yml
@@ -1,4 +1,6 @@
 ---
+require: rubocop-rails
+
 Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: false

--- a/rubocop/layout.yml
+++ b/rubocop/layout.yml
@@ -41,7 +41,7 @@ Layout/ConditionPosition:
 
 Layout/IndentationConsistency:
   Description: 'Checks for inconsistent indentation.'
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 Layout/MultilineBlockLayout:
   Description: 'Checks whether the multiline do end blocks have a newline after the start of the block.'


### PR DESCRIPTION
Styles specifically related to Rails were moved into the rubocop-rails gem.