### PR TITLE
Update Rubocop to 0.79; policy changes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,5 +14,5 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
-Metrics/LineLength:
+Layout/LineLength:
   Max: 114

--- a/niftany.gemspec
+++ b/niftany.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'colorize', '~> 0.8.1'
   spec.add_dependency 'erb_lint', '~> 0.0.22'
-  spec.add_dependency 'rubocop', '~> 0.61'
+  spec.add_dependency 'rubocop', '~> 0.79'
   spec.add_dependency 'rubocop-performance', '~> 1.1'
   spec.add_dependency 'rubocop-rails', '~> 2.3'
   spec.add_dependency 'rubocop-rspec', '~> 1.3'

--- a/niftany_erblint.yml
+++ b/niftany_erblint.yml
@@ -22,7 +22,7 @@ linters:
           - niftany_rubocop_rails.yml
       Layout/InitialIndentation:
         Enabled: false
-      Layout/TrailingBlankLines:
+      Layout/TrailingEmptyLines:
         Enabled: false
       Layout/TrailingWhitespace:
         Enabled: false
@@ -30,7 +30,7 @@ linters:
         Enabled: false
       Style/FrozenStringLiteralComment:
         Enabled: false
-      Metrics/LineLength:
+      Layout/LineLength:
         Enabled: false
       Lint/UselessAssignment:
         Enabled: false

--- a/niftany_rubocop_rspec.yml
+++ b/niftany_rubocop_rspec.yml
@@ -43,3 +43,11 @@ RSpec/DescribeClass:
 
 RSpec/BeforeAfterAll:
   Enabled: false
+
+RSpec/ExampleLength:
+  Enabled:
+    false
+
+RSpec/MultipleExpectations:
+  Enabled:
+    false

--- a/rubocop/layout.yml
+++ b/rubocop/layout.yml
@@ -1,5 +1,5 @@
 ---
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Description: 'Here we check if the parameters on a multi-line method call or definition are aligned.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
   Enabled: false
@@ -46,3 +46,9 @@ Layout/IndentationConsistency:
 Layout/MultilineBlockLayout:
   Description: 'Checks whether the multiline do end blocks have a newline after the start of the block.'
   Enabled: true
+
+Layout/LineLength:
+  Description: 'Limit lines to 120 characters.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
+  Enabled: true
+  Max: 120

--- a/rubocop/lint.yml
+++ b/rubocop/lint.yml
@@ -25,7 +25,7 @@ Lint/DeprecatedClassMethods:
   Description: 'Check for deprecated class method calls.'
   Enabled: false
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Description: 'Check for duplicate keys in hash literals.'
   Enabled: true
 
@@ -41,7 +41,7 @@ Lint/FormatParameterMismatch:
   Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: false
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Description: "Don't suppress exception."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: false

--- a/rubocop/metrics.yml
+++ b/rubocop/metrics.yml
@@ -1,4 +1,8 @@
 ---
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
@@ -29,13 +33,6 @@ Metrics/PerceivedComplexity:
                 This cop tries to produce a complexity score that's a measure of the complexity
                 the reader experiences when looking at a method
   Enabled: true
-
-# Override style guide to allow length of up to 120 characters.
-Metrics/LineLength:
-  Description: 'Limit lines to 120 characters.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
-  Enabled: true
-  Max: 120
 
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 10 lines of code.'

--- a/rubocop/naming.yml
+++ b/rubocop/naming.yml
@@ -21,7 +21,7 @@ Naming/BinaryOperatorParameterName:
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
 
 Naming/VariableName:


### PR DESCRIPTION
Updates the Rubocop gem to version 0.79, which requires changing the names to some of the parameters.

Includes additional changes to RSpec, and not checking for the size and number of the tests.