### PR TITLE
Adds configuration for cops introduced in `rubocop 0.83`

### DIFF
--- a/rubocop/layout.yml
+++ b/rubocop/layout.yml
@@ -55,3 +55,6 @@ Layout/LineLength:
 
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true

--- a/rubocop/style.yml
+++ b/rubocop/style.yml
@@ -321,3 +321,6 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: false
+
+Style/SlicingWithRange:
+  Enabled: true


### PR DESCRIPTION
Not sure if there's more to it, but just addressing these warnings:

```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Layout/EmptyLinesAroundAttributeAccessor (0.83)
 - Style/SlicingWithRange (0.83)
For more information: https://docs.rubocop.org/en/latest/versioning/
```