### PR TITLE
Enables all new cops as they're added by default

### DIFF
--- a/niftany_rubocop_ruby.yml
+++ b/niftany_rubocop_ruby.yml
@@ -9,3 +9,4 @@ inherit_from:
 
 AllCops:
   DisplayCopNames: true
+  NewCops: enable


### PR DESCRIPTION
This makes upgrades less painful, basically an opt-in by default and an opt-out is a manual action. See https://docs.rubocop.org/rubocop/0.87/versioning.html#pending-cops