### PR TITLE
Adds --parallel option for rubocop

### DIFF
--- a/exe/niftany
+++ b/exe/niftany
@@ -12,12 +12,17 @@ require 'colorize'
 def parse_opts(args)
   options = OpenStruct.new
   options.auto_correct = false
+  options.parallel = false
 
   parser = OptionParser.new do |opts|
     opts.banner = 'Usage: niftany [options]'
 
     opts.on('-a', '--auto-correct', 'Correct violations') do |auto|
       options.auto_correct = auto
+    end
+
+    opts.on('-p', '--parallel', 'Run RuboCop in parallel') do |parallel|
+      options.parallel = parallel
     end
 
     opts.on_tail('-h', '--help', 'Show this message') do
@@ -30,9 +35,10 @@ def parse_opts(args)
 end
 
 def rubocop_options(options)
-  return [] unless options.auto_correct
-
-  ['--auto-correct']
+  rubocop_options = []
+  rubocop_options.append('--auto-correct') if options.auto_correct
+  rubocop_options.append('--parallel') if options.parallel
+  rubocop_options
 end
 
 def erblint_options(options)

--- a/niftany.gemspec
+++ b/niftany.gemspec
@@ -3,6 +3,7 @@
 Gem::Specification.new do |spec|
   spec.name          = 'niftany'
   spec.version       = '0.8.0'
+  spec.required_ruby_version = ['>= 2.6.0']
   spec.authors       = ['Adam Wead']
   spec.email         = ['amsterdamos@gmail.com']
   spec.summary       = 'Manages configurations and versions of linters used in projects at '\


### PR DESCRIPTION
Adds --parallel flag, which gets passed to RuboCop, allowing for faster linting in environments where there isn't a rubocop cache