### PR TITLE
allcops does not support rspec

### DIFF
--- a/niftany.gemspec
+++ b/niftany.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'niftany'
-  spec.version       = '0.10.0'
+  spec.version       = '0.10.1'
   spec.metadata      = { 'rubygems_mfa_required' => 'true' }
   spec.authors       = ['Adam Wead']
   spec.email         = ['amsterdamos@gmail.com']

--- a/niftany_rubocop_rspec.yml
+++ b/niftany_rubocop_rspec.yml
@@ -1,12 +1,6 @@
 ---
 require: rubocop-rspec
 
-AllCops:
-  RSpec:
-    Patterns:
-    - _spec.rb
-    - "(?:^|/)spec/"
-
 Layout/MultilineBlockLayout:
   Exclude:
     - 'spec/**/*'


### PR DESCRIPTION
removes warning message when using niftany 0.10 for unsupported parameter

Fixes #26 